### PR TITLE
5 packages from patricoferris/eio at 1.2.0~shark

### DIFF
--- a/packages/eio/eio.1.2.0~shark/opam
+++ b/packages/eio/eio.1.2.0~shark/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.1.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src: "https://github.com/patricoferris/eio/archive/heads/shark.tar.gz"
+  checksum: [
+    "md5=1164758bb57b318538e8c567d9e17ab8"
+    "sha512=61ad563be0c695eb9570f7480a66d8d9593e7ef2ed3d82a14d77b22bd47b479604cab9cd58215bd4ac8c3404e47004265b2d00799ad0fccf633816d9d721907b"
+  ]
+}

--- a/packages/eio_linux/eio_linux.1.2.0~shark/opam
+++ b/packages/eio_linux/eio_linux.1.2.0~shark/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.4.1" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.9"}
+  "odoc" {with-doc}
+]
+available: os = "linux"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src: "https://github.com/patricoferris/eio/archive/heads/shark.tar.gz"
+  checksum: [
+    "md5=1164758bb57b318538e8c567d9e17ab8"
+    "sha512=61ad563be0c695eb9570f7480a66d8d9593e7ef2ed3d82a14d77b22bd47b479604cab9cd58215bd4ac8c3404e47004265b2d00799ad0fccf633816d9d721907b"
+  ]
+}

--- a/packages/eio_main/eio_main.1.2.0~shark/opam
+++ b/packages/eio_main/eio_main.1.2.0~shark/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.4.1" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src: "https://github.com/patricoferris/eio/archive/heads/shark.tar.gz"
+  checksum: [
+    "md5=1164758bb57b318538e8c567d9e17ab8"
+    "sha512=61ad563be0c695eb9570f7480a66d8d9593e7ef2ed3d82a14d77b22bd47b479604cab9cd58215bd4ac8c3404e47004265b2d00799ad0fccf633816d9d721907b"
+  ]
+}
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/eio_posix/eio_posix.1.2.0~shark/opam
+++ b/packages/eio_posix/eio_posix.1.2.0~shark/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.4.1" & with-test}
+  "conf-bash" {with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src: "https://github.com/patricoferris/eio/archive/heads/shark.tar.gz"
+  checksum: [
+    "md5=1164758bb57b318538e8c567d9e17ab8"
+    "sha512=61ad563be0c695eb9570f7480a66d8d9593e7ef2ed3d82a14d77b22bd47b479604cab9cd58215bd4ac8c3404e47004265b2d00799ad0fccf633816d9d721907b"
+  ]
+}

--- a/packages/eio_windows/eio_windows.1.2.0~shark/opam
+++ b/packages/eio_windows/eio_windows.1.2.0~shark/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src: "https://github.com/patricoferris/eio/archive/heads/shark.tar.gz"
+  checksum: [
+    "md5=1164758bb57b318538e8c567d9e17ab8"
+    "sha512=61ad563be0c695eb9570f7480a66d8d9593e7ef2ed3d82a14d77b22bd47b479604cab9cd58215bd4ac8c3404e47004265b2d00799ad0fccf633816d9d721907b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `eio.1.2.0~shark`: Effect-based direct-style IO API for OCaml
- `eio_linux.1.2.0~shark`: Eio implementation for Linux using io-uring
- `eio_main.1.2.0~shark`: Effect-based direct-style IO mainloop for OCaml
- `eio_posix.1.2.0~shark`: Eio implementation for POSIX systems
- `eio_windows.1.2.0~shark`: Eio implementation for Windows



---
* Homepage: https://github.com/ocaml-multicore/eio
* Source repo: git+https://github.com/ocaml-multicore/eio.git
* Bug tracker: https://github.com/ocaml-multicore/eio/issues

---
:camel: Pull-request generated by opam-publish v2.4.0