### PR TITLE
4 packages from patricoferris/ocaml-tar at 3.1.2~shark

### DIFF
--- a/packages/tar-eio/tar-eio.3.1.2~shark/opam
+++ b/packages/tar-eio/tar-eio.3.1.2~shark/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files using Eio"
+description: """\
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library uses Eio to provide a portable tar library."""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.00.0"}
+  "eio" {>= "1.1"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src: "https://github.com/patricoferris/ocaml-tar/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=0e095ad401cc7fa4a14d4b0ed2239472"
+    "sha512=2783b2066ec0e2d8dc3a7be9265be4956e77f460adb15021f20e97fe02e1012529616d0edd536903b9917570bff6d3f248a2044d44900c7758d0a15ce409b83c"
+  ]
+}

--- a/packages/tar-mirage/tar-mirage.3.1.2~shark/opam
+++ b/packages/tar-mirage/tar-mirage.3.1.2~shark/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """\
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS."""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src: "https://github.com/patricoferris/ocaml-tar/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=0e095ad401cc7fa4a14d4b0ed2239472"
+    "sha512=2783b2066ec0e2d8dc3a7be9265be4956e77f460adb15021f20e97fe02e1012529616d0edd536903b9917570bff6d3f248a2044d44900c7758d0a15ce409b83c"
+  ]
+}

--- a/packages/tar-unix/tar-unix.3.1.2~shark/opam
+++ b/packages/tar-unix/tar-unix.3.1.2~shark/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """\
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface."""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.7.0"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src: "https://github.com/patricoferris/ocaml-tar/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=0e095ad401cc7fa4a14d4b0ed2239472"
+    "sha512=2783b2066ec0e2d8dc3a7be9265be4956e77f460adb15021f20e97fe02e1012529616d0edd536903b9917570bff6d3f248a2044d44900c7758d0a15ce409b83c"
+  ]
+}

--- a/packages/tar/tar.3.1.2~shark/opam
+++ b/packages/tar/tar.3.1.2~shark/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """\
+tar is a library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings."""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src: "https://github.com/patricoferris/ocaml-tar/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=0e095ad401cc7fa4a14d4b0ed2239472"
+    "sha512=2783b2066ec0e2d8dc3a7be9265be4956e77f460adb15021f20e97fe02e1012529616d0edd536903b9917570bff6d3f248a2044d44900c7758d0a15ce409b83c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `tar.3.1.2~shark`: Decode and encode tar format files in pure OCaml
- `tar-eio.3.1.2~shark`: Decode and encode tar format files using Eio
- `tar-mirage.3.1.2~shark`: Read and write tar format files via MirageOS interfaces
- `tar-unix.3.1.2~shark`: Decode and encode tar format files from Unix



---
* Homepage: https://github.com/mirage/ocaml-tar
* Source repo: git+https://github.com/mirage/ocaml-tar.git
* Bug tracker: https://github.com/mirage/ocaml-tar/issues

---
:camel: Pull-request generated by opam-publish v2.4.0