### PR TITLE
20 packages from mirage/irmin at 4.0.0

### DIFF
--- a/packages/irmin-bench/irmin-bench.4.0.0/opam
+++ b/packages/irmin-bench/irmin-bench.4.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Irmin benchmarking suite"
+description: """\
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations."""
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "3.5.0"}
+  "irmin-pack" {= version}
+  "irmin-test" {= version}
+  "irmin-tezos" {= version}
+  "cmdliner"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "repr" {>= "0.3.0"}
+  "ppx_repr"
+  "re" {>= "1.9.0"}
+  "fmt"
+  "uuidm"
+  "progress" {>= "0.2.1"}
+  "fpath" {with-test}
+  "bentov"
+  "mtime" {>= "2.0.0"}
+  "ppx_deriving"
+  "alcotest" {with-test}
+  "rusage"
+  "uutf"
+  "uucp"
+  "printbox" {>= "0.6"}
+  "printbox-text"
+]
+available: arch != "arm32" & arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-chunk/irmin-chunk.4.0.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.4.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Irmin backend which allow to store values into chunks"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "fmt"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-cli/irmin-cli.4.0.0/opam
+++ b/packages/irmin-cli/irmin-cli.4.0.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "CLI for Irmin"
+description:
+  "A simple CLI tool (called `irmin`) to manipulate and inspect Irmin stores."
+maintainer: "Tarides <contact@tarides.com>"
+authors: "Tarides"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "irmin-git" {= version}
+  "irmin-fs" {= version}
+  "irmin-pack" {= version}
+  "irmin-graphql" {= version}
+  "irmin-tezos" {= version}
+  "irmin-server" {= version}
+  "irmin-watcher" {= "dev"}
+  "git-unix" {>= "3.7.0"}
+  "digestif" {>= "0.9.0"}
+  "yaml" {>= "3.0.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix" {>= "6.0.0"}
+  "websocket-lwt-unix"
+  "ppx_blob" {>= "0.7.2"}
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git" {>= "3.7.0"}
+  "happy-eyeballs-lwt"
+  "eio_main" {>= "1.0"}
+  "lwt_eio" {>= "0.5"}
+  "lwt" {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest" {with-test}
+  "mdx" {>= "2.0.0" & with-test}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+pin-depends: [
+  "irmin-watcher.dev"
+  "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-client/irmin-client.4.0.0/opam
+++ b/packages/irmin-client/irmin-client.4.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A client for irmin-server"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: "Zach Shipko <zachshipko@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://irmin.org"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin-server" {= version}
+  "irmin-cli" {= version}
+  "ipaddr"
+  "websocket-lwt-unix"
+  "conduit-lwt-unix" {>= "6.0.0"}
+  "lwt-dllist"
+  "js_of_ocaml-lwt"
+  "brr" {>= "0.0.4"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.7.0"}
+  "irmin-test" {= version & with-test}
+  "irmin-watcher" {= "dev" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+ssh://github.com/mirage/irmin"
+pin-depends: [
+  "irmin-watcher.dev"
+  "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-containers/irmin-containers.4.0.0/opam
+++ b/packages/irmin-containers/irmin-containers.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Mergeable Irmin data structures"
+description: """\
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways."""
+maintainer: "thomas@gazagnaire.org"
+authors: ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "irmin-fs" {= version}
+  "ppx_irmin" {= version}
+  "lwt" {>= "5.3.0"}
+  "mtime" {>= "2.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-fs/irmin-fs.4.0.0/opam
+++ b/packages/irmin-fs/irmin-fs.4.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Generic file-system backend for Irmin"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "astring"
+  "logs"
+  "eio" {>= "1.0"}
+  "lwt" {>= "5.3.0"}
+  "alcotest" {with-test}
+  "irmin-test" {with-test & = version}
+  "irmin-watcher" {with-test & = "dev"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+pin-depends: [
+  "irmin-watcher.dev"
+  "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-git/irmin-git.4.0.0/opam
+++ b/packages/irmin-git/irmin-git.4.0.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Git backend for Irmin"
+description: """\
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores."""
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "ppx_irmin" {= version}
+  "git" {>= "3.14.0"}
+  "git-unix" {>= "3.14.0"}
+  "digestif" {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "cohttp-lwt-unix"
+  "fpath"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "lwt_eio" {>= "0.5"}
+  "uri"
+  "mimic"
+  "irmin-test" {with-test & = version}
+  "mtime" {with-test & >= "2.0.0"}
+  "alcotest" {with-test}
+  "irmin-watcher" {= "dev"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs]
+    {with-test & arch != "arm32" & arch != "x86_32"}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+pin-depends: [
+  "irmin-watcher.dev"
+  "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-graphql/irmin-graphql.4.0.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.4.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "GraphQL server for Irmin"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "graphql" {>= "0.14.0"}
+  "graphql-lwt" {>= "0.14.0"}
+  "graphql-cohttp" {>= "0.14.0"}
+  "graphql_parser" {>= "0.14.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "git-unix" {>= "3.7.0"}
+  "fmt"
+  "lwt" {>= "5.3.0"}
+  "lwt_eio" {>= "0.5"}
+  "yojson" {with-test}
+  "alcotest" {with-test & >= "1.2.3"}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-http/irmin-http.4.0.0/opam
+++ b/packages/irmin-http/irmin-http.4.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "HTTP client and server for Irmin"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "crunch" {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin" {= version}
+  "ppx_irmin" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "lwt_eio" {>= "0.3"}
+  "uri"
+  "irmin-git" {with-test & = version}
+  "irmin-fs" {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "git-unix" {with-test & >= "3.5.0"}
+  "digestif" {with-test & >= "0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-mirage-git/irmin-mirage-git.4.0.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.4.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "MirageOS-compatible Irmin stores"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "3.5.0"}
+  "irmin-mirage" {= version}
+  "irmin-git" {= version}
+  "mirage-kv" {>= "6.0.0"}
+  "fmt"
+  "git" {>= "3.7.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock"
+  "uri"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.4.0.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.4.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "MirageOS-compatible Irmin stores"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "3.5.0"}
+  "irmin-mirage" {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt" {>= "5.3.0"}
+  "uri"
+  "git" {>= "3.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-mirage/irmin-mirage.4.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.4.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "MirageOS-compatible Irmin stores"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+  "lwt_eio" {>= "0.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-pack-tools/irmin-pack-tools.4.0.0/opam
+++ b/packages/irmin-pack-tools/irmin-pack-tools.4.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Utils for Irmin-pack"
+description: """\
+`Irmin-pack-tools` defines useful binaries and libraries for
+an internal use of irmin-pack, like dumping control files in
+a readable json format and such."""
+maintainer: "Gwenaelle@tarides.com"
+authors: "Gwenaëlle Lecat"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin-tezos" {= version}
+  "irmin-pack" {= version}
+  "irmin-pack" {= version}
+  "index" {>= "1.6.2"}
+  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "notty" {>= "0.2.3"}
+  "index" {>= "dev"}
+  "ppx_repr" {>= "0.7.0"}
+  "ptime"
+  "hex"
+  "irmin-test" {with-test & = version}
+  "alcotest" {with-test}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.4.0.0/opam
+++ b/packages/irmin-pack/irmin-pack.4.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Irmin backend which stores values in a pack file"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "irmin" {= version}
+  "ppx_irmin" {= version}
+  "index" {= "dev"}
+  "fmt"
+  "logs"
+  "eio" {>= "1.0"}
+  "mtime" {>= "2.0.0"}
+  "cmdliner"
+  "optint" {>= "0.1.0"}
+  "checkseum"
+  "rusage"
+  "progress" {= "dev"}
+  "irmin-test" {with-test & = version}
+  "astring" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+pin-depends: [
+  [
+    "terminal.dev"
+    "git+https://github.com/craigfe/progress#ac53cd48cd82500f51faf67f9555a9454d5f5504"
+  ]
+  [
+    "progress.dev"
+    "git+https://github.com/craigfe/progress#ac53cd48cd82500f51faf67f9555a9454d5f5504"
+  ]
+  [
+    "index.dev"
+    "git+https://github.com/mirage/index#09ab315dcfe6c1affbbb01c737f1b8e235b04eca"
+  ]
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-server/irmin-server.4.0.0/opam
+++ b/packages/irmin-server/irmin-server.4.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A high-performance server for Irmin"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: "Zach Shipko <zachshipko@gmail.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://irmin.org"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "optint" {>= "0.1.0"}
+  "irmin" {= version}
+  "ppx_irmin" {= version}
+  "irmin-pack" {= version}
+  "uri"
+  "fmt"
+  "cmdliner" {>= "1.0.4"}
+  "logs" {>= "0.7.0"}
+  "eio_main" {>= "1.0"}
+  "lwt_eio" {>= "0.5.1"}
+  "lwt" {>= "5.4.0"}
+  "conduit-lwt-unix" {>= "6.0.0"}
+  "websocket-lwt-unix"
+  "cohttp-lwt-unix"
+  "ppx_blob" {>= "0.7.2"}
+  "digestif" {>= "1.1.4"}
+  "irmin-watcher" {= "dev" & with-test}
+  "irmin-test" {= version & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+ssh://github.com/mirage/irmin"
+pin-depends: [
+  "irmin-watcher.dev"
+  "git+https://github.com/patricoferris/irmin-watcher#d0e92b4ba5631b5f4dc0f3c00d97e79542dba45d"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-test/irmin-test.4.0.0/opam
+++ b/packages/irmin-test/irmin-test.4.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Irmin test suite"
+description: """\
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations."""
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "irmin" {= version}
+  "ppx_irmin" {= version}
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "mtime" {>= "2.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "eio" {>= "1.0"}
+  "eio_main" {>= "0.15"}
+  "alcotest" {>= "dev"}
+  "qcheck-alcotest" {with-test & >= "0.21.1"}
+  "metrics" {>= "0.4.1"}
+  "metrics-unix" {>= "0.4.1"}
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "hex" {with-test & >= "1.4.0"}
+  "vector" {with-test & >= "1.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "qcheck-alcotest" {>= "0.21.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+pin-depends: [
+  "alcotest.dev"
+  "git+https://github.com/haesbaert/alcotest#99030be1df12a17fc2a0f3d00b181cd31cf6b0d4"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin-tezos/irmin-tezos.4.0.0/opam
+++ b/packages/irmin-tezos/irmin-tezos.4.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Irmin implementation of the Tezos context hash specification"
+description: "Irmin implementation of the Tezos context hash specification"
+maintainer: "Tarides <contact@tarides.com>"
+authors: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "3.5.0"}
+  "irmin" {>= version}
+  "irmin-pack" {= version}
+  "ppx_irmin" {= version}
+  "tezos-base58"
+  "digestif" {>= "0.7"}
+  "cmdliner"
+  "fmt"
+  "yojson"
+  "alcotest" {with-test}
+  "hex" {with-test & >= "1.4.0"}
+  "fpath" {with-test}
+  "irmin-test" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/irmin/irmin.4.0.0/opam
+++ b/packages/irmin/irmin.4.0.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis:
+  "Irmin, a distributed database that follows the same design principles as Git"
+description: """\
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels."""
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+doc: "https://mirage.github.io/irmin/"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.5.0"}
+  "repr" {>= "0.6.0"}
+  "fmt" {>= "0.8.5"}
+  "uri" {>= "1.3.12"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "eio" {>= "1.0"}
+  "lwt" {>= "5.6.1"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs" {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "mtime" {>= "2.0.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "ppx_irmin" {= version}
+  "eio_main" {>= "1.0" & with-test}
+  "hex" {with-test}
+  "alcotest" {= "dev" & with-test}
+  "qcheck-alcotest" {with-test}
+  "vector" {with-test}
+  "odoc" {(< "2.0.1" | > "2.0.2") & with-doc}
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+pin-depends: [
+  "alcotest.dev"
+  "git+https://github.com/haesbaert/alcotest#99030be1df12a17fc2a0f3d00b181cd31cf6b0d4"
+]
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/libirmin/libirmin.4.0.0/opam
+++ b/packages/libirmin/libirmin.4.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "C bindings for irmin"
+description: "C bindings for irmin using Ctypes inverted stubs"
+maintainer: "zachshipko@gmail.com"
+authors: "Zach Shipko"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "3.5.0"}
+  "ctypes" {>= "0.19"}
+  "ctypes-foreign" {>= "0.18"}
+  "irmin" {= version}
+  "irmin-cli" {= version}
+  "eio_main" {>= "1.0"}
+  "lwt_eio" {>= "0.5"}
+]
+available: arch != "arm64" & arch != "s390x" & os != "macos"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}

--- a/packages/ppx_irmin/ppx_irmin.4.0.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.4.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for Irmin type representations"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+authors: "Craig Ferguson <craig@tarides.com>"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "3.5.0"}
+  "ppx_repr" {>= "0.2.0"}
+  "ppxlib" {>= "0.12.0"}
+  "logs" {>= "0.5.0"}
+  "fmt" {with-test & >= "0.8.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src: "https://github.com/mirage/irmin/archive/heads/eio.tar.gz"
+  checksum: [
+    "md5=8f786632e51147109b09d18d01a0a96c"
+    "sha512=35dd6018477276161d8903133d9a9fe27c4fc92c29cd248a009a2d8de81849da2ada1f5c73f0692abba0b6f65b263c24b906fc671fdf030760963046b6431ef3"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `irmin.4.0.0`: Irmin, a distributed database that follows the same design principles as Git
- `irmin-bench.4.0.0`: Irmin benchmarking suite
- `irmin-chunk.4.0.0`: Irmin backend which allow to store values into chunks
- `irmin-cli.4.0.0`: CLI for Irmin
- `irmin-client.4.0.0`: A client for irmin-server
- `irmin-containers.4.0.0`: Mergeable Irmin data structures
- `irmin-fs.4.0.0`: Generic file-system backend for Irmin
- `irmin-git.4.0.0`: Git backend for Irmin
- `irmin-graphql.4.0.0`: GraphQL server for Irmin
- `irmin-http.4.0.0`: HTTP client and server for Irmin
- `irmin-mirage.4.0.0`: MirageOS-compatible Irmin stores
- `irmin-mirage-git.4.0.0`: MirageOS-compatible Irmin stores
- `irmin-mirage-graphql.4.0.0`: MirageOS-compatible Irmin stores
- `irmin-pack.4.0.0`: Irmin backend which stores values in a pack file
- `irmin-pack-tools.4.0.0`: Utils for Irmin-pack
- `irmin-server.4.0.0`: A high-performance server for Irmin
- `irmin-test.4.0.0`: Irmin test suite
- `irmin-tezos.4.0.0`: Irmin implementation of the Tezos context hash specification
- `libirmin.4.0.0`: C bindings for irmin
- `ppx_irmin.4.0.0`: PPX deriver for Irmin type representations



---
* Homepage: https://github.com/mirage/irmin
* Bug tracker: https://github.com/mirage/irmin/issues

---
:camel: Pull-request generated by opam-publish v2.4.0